### PR TITLE
Small changes for dependency refs

### DIFF
--- a/australis/customization/mac/www/js/app/main.js
+++ b/australis/customization/mac/www/js/app/main.js
@@ -2,15 +2,15 @@ define(function (require) {
   var $ = require("jquery");
   var _ = require("underscore");
   var Backbone = require("backbone");
-  var unused = require("./tags");
-  var unused = require("./models");
-  var unused = require("jquery-ui");
-  var unused = require("jquery.contextMenu");
+  require("./tags");
+  require("./models");
+  require("jquery-ui");
+  require("jquery.contextMenu");
 
   function toggleBookmarkStar() {
     $('.bookmarkStar').toggleClass('starred');
   }
-  
+
   function toggleCustomizeTab() {
     $("div.windowOuterContainer").toggleClass("customizeMode");
     $("div.window").toggleClass("customizeMode");

--- a/australis/customization/mac/www/js/app/tags.js
+++ b/australis/customization/mac/www/js/app/tags.js
@@ -1,4 +1,4 @@
-define(["jquery", "x-tag"], function ($, tag) {
+define(["jquery", "x-tag"], function ($, xtag) {
 
   xtag.register("toolbar-item", {
     onCreate: function(){


### PR DESCRIPTION
fixed a typo with xtag local reference, and removed the var unused stuff. Doing a `volo build` seemed to produce the desired built output in www-built/js/app.js.
